### PR TITLE
Add GitHub Codespaces devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  "name": "ExtractInformationPDFs",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11",
+  "features": {
+    "ghcr.io/devcontainers/features/azure-cli:1": {}
+  },
+  "postCreateCommand": "pip install --upgrade pip && pip install -r app/requirements.txt pytest",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": [
+          "tests"
+        ]
+      },
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+      ]
+    }
+  },
+  "remoteUser": "vscode"
+}


### PR DESCRIPTION
## Summary
- add a devcontainer definition for GitHub Codespaces based on the Python 3.11 image with Azure CLI support
- install project requirements and pytest automatically and preconfigure VS Code testing settings

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2c0e0ea44832fbca5bbec82d4798f